### PR TITLE
Reformat integer game scores as locale-formatted strings.

### DIFF
--- a/mobile/src/main/java/com/acmetensortoys/ctfwstimer/CtFwSDisplayLocal.java
+++ b/mobile/src/main/java/com/acmetensortoys/ctfwstimer/CtFwSDisplayLocal.java
@@ -356,8 +356,9 @@ class CtFwSDisplayLocal implements CtFwSGameStateManager.Observer {
         Resources rs = mAct.getResources();
 
         if (gs.getFlagsVisible()) {
+            NumberFormat nf = NumberFormat.getIntegerInstance();
             h = AndroidResourceUtils.htmlFromStrResId(rs, R.string.flags_viz_fmt,
-                    gs.getFlagsRed(), gs.getFlagsYel());
+                    nf.format(gs.getFlagsRed()), nf.format(gs.getFlagsYel()));
         } else {
             h = AndroidResourceUtils.htmlFromStrResId(rs, R.string.flags_noviz);
         }

--- a/mobile/src/main/java/com/acmetensortoys/ctfwstimer/MainServiceNotification.java
+++ b/mobile/src/main/java/com/acmetensortoys/ctfwstimer/MainServiceNotification.java
@@ -139,9 +139,10 @@ class MainServiceNotification {
                             || (game.getFlagsRed() + game.getFlagsYel() > 0))) {
                     notifyUserSomehow(NotificationSource.FLAG);
                     lastContextTextSource = LastContentTextSource.FLAG;
+                    NumberFormat nf = NumberFormat.getIntegerInstance();
                     userNoteBuilder.setContentText(
                             String.format(mService.getResources().getString(R.string.notify_flags),
-                                    game.getFlagsRed(), game.getFlagsYel()));
+                                    nf.format(game.getFlagsRed()), nf.format(game.getFlagsYel())));
                     refreshNotification();
                 }
             }

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="dialog_reset">Default</string>
 
     <string name="flags_viz_fmt">
-        <![CDATA[<font color=#a94442><b>Red</b>: %1$d</font>, <font color=#8a6d3b><b>Yellow</b>: %2$d</font>]]>
+        <![CDATA[<font color=#a94442><b>Red</b>: %1$s</font>, <font color=#8a6d3b><b>Yellow</b>: %2$s</font>]]>
     </string>
     <string name="flags_noviz">Flag scores hidden</string>
 
@@ -35,7 +35,7 @@
     <string name="notify_start_future">Start time in the future!</string>
     <string name="notify_game_over">Game over!</string>
     <string name="notify_not_config">Game not configured!</string>
-    <string name="notify_flags" tools:ignore="PluralsCandidate">Flag captured! Red:%1$d Yellow:%2$d</string>
+    <string name="notify_flags" tools:ignore="PluralsCandidate">Flag captured! Red:%1$s Yellow:%2$s</string>
     <string name="notify_jailbreak">Jailbreak %1$d of %2$d</string>
 
     <string name="menutext_about">About</string>


### PR DESCRIPTION
Resolves #16… at least that's the hope.

@nwf Please do review and test.  StackOverflow simply pointed me toward https://developer.android.com/reference/java/text/NumberFormat.html and I went from there.

Happily, this also lays a little of the potential groundwork for scores that are non-integers or are otherwise more arbitrary strings.